### PR TITLE
Fix/#2 Fix two issues regarding table creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "rss-watcher"
-version = "0.1.0"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss-watcher"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]

--- a/src/database.rs
+++ b/src/database.rs
@@ -120,7 +120,7 @@ fn run_migrations_v2(tx: &mut Transaction, version: i64) {
     if version < 2 {
         warn!("Running migrations to v2");
         let mut q;
-        q = "ALTER TABLE `rss_watcher`.`rss-watcher-feeds` \
+        q = "ALTER TABLE `rss-watcher-feeds` \
              CHANGE COLUMN `title` `title` VARCHAR(255) NOT NULL DEFAULT '{{title}}: {{entry.title}}' , \
              CHANGE COLUMN `message` `message` VARCHAR(255) NOT NULL DEFAULT '{{entry.summary}}';";
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -75,6 +75,10 @@ fn table_create(conn: &mut Conn) {
         error!("Could not create table! ({:#?}", x);
         process::exit(1);
     }
+    if let Err(x) = tx.query_drop("SET SESSION sql_mode='NO_AUTO_VALUE_ON_ZERO'") {
+        error!("Could not set NO_AUTO_VALUE_ON_ZERO sql_mode for session, you might have to change the id of this row manually from 1 to 0! ({:#?}", x);
+        process::exit(1);
+    }
     q = "INSERT INTO `rss-watcher-feeds` (id,
                                           url,
                                           last_fetch,


### PR DESCRIPTION
- Fix issue with not allowing arbitrary database name
- Fix issue where `sql_mode='NO_AUTO_VALUE_ON_ZERO'` is not the default anymore. Allowing the `version` column to have both `id=0` and `id=1`.